### PR TITLE
added pdf support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Before you proceed, please ensure that you have downloaded and installed Node.js
 
 # How to use
 
-  - Download this repo 
-  - Navigate inside it with command-line, and install all the packages: 
+  - Download this repo
+  - Navigate inside it with command-line, and install all the packages:
 ```ch
 npm install
 ```  
-- Run the server by typing: 
+- Run the server by typing:
 ```ch
 npm run dev
 ```  
@@ -37,8 +37,14 @@ Make POST as request method, change "Content-Type" to "multipart/form-data", and
 
 ##### Entity body
 ![POST2](https://i.imgur.com/JUkbvub.png)
-  
-  
+
+### PDF Post Request
+As of now, PDF POST works only with one number.  
+Url to test: localhost:8000/api/phonenumbers/parse/pdf
+Make sure to set POST as request method and included "multipart/form-data" for "Content-Type" before sending request:
+![POST](https://i.imgur.com/Feqiwqf.png)
+
+
 ### TESTING
 First, make sure your server is not running because it will prevent tests from running.  
 Assuming you are still in the root of project, run this command:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2795,6 +2795,14 @@
         "through": "2.3.8"
       }
     },
+    "pdf-text-extract": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/pdf-text-extract/-/pdf-text-extract-1.5.0.tgz",
+      "integrity": "sha1-SmtkjZA/VVLUi9mETjZEZFK4XmA=",
+      "requires": {
+        "yargs": "1.3.3"
+      }
+    },
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -3846,6 +3854,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "yargs": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz",
+      "integrity": "sha1-BU3oth8i7v23IHBZ6u+da4P7kxo="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "body-parser": "^1.18.2",
     "express": "^4.16.2",
     "google-libphonenumber": "^3.0.10",
-    "multer": "^1.3.0"
+    "multer": "^1.3.0",
+    "pdf-text-extract": "^1.5.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/server.js
+++ b/server.js
@@ -42,6 +42,31 @@ app.post('/api/phonenumbers/parse/file', upload.single('file'), (req, res) => {
   }
 });
 
+app.post('/api/phonenumbers/parse/pdf', upload.single('file'), (req, res) => {
+
+  if(!req.file) {
+    res.status(400).send('No file received');
+  }
+  else {
+    var path = require('path')
+    var filePath = path.join(__dirname, req.file.path)
+    var extract = require('pdf-text-extract')
+
+    extract(filePath, { splitPages: false }, function (err, text) {
+      if (err) {
+        res.status(400).send("Exception caught: " + err);
+        //return bad pdf
+        return
+      }
+
+      var finalArr = numParser(text, res);
+	    res.status(200).send(finalArr);
+
+    })
+
+  }
+});
+
 app.listen(8000, () => {
   console.log('The server is running on port 8000');
 });

--- a/test.js
+++ b/test.js
@@ -59,3 +59,18 @@ describe('API endpoint /api/phonenumbers/parse/file', () => {
        });
      })
 });
+
+describe('API endpoint /api/phonenumbers/parse/file', () => {
+
+  // POST - pdf
+  it('should return [\'+1 905-887-2216\']', () => {
+      return chai.request(app)
+        .post('/api/phonenumbers/parse/pdf')
+        .set('Content-Type', 'multipart/plain')
+        .attach('file', fs.readFileSync('./test_phone_number.pdf'), 'test_phone_number.pdf')
+        .then((res) => {
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.an('array').that.include('+1 905-887-2216');
+       });
+     })
+});


### PR DESCRIPTION
This PR adds support for parsing PDF's. The route to use it is: /api/phonenumbers/parse/pdf. I have try to keep my code as close to yours as possible. This feature does not support multiple phone numbers in PDF's. In addition, I have created another test to prove that this feature works. There is one test that is failing for me but I think that's because of some weird port issues I'm having. Also, I updated the readme so that it gives instructions to use the pdf feature.

Thanks for considering this request.
