### PR TITLE
issue #2 added a delimiter to handle multiple phone numbers

### DIFF
--- a/server.js
+++ b/server.js
@@ -18,7 +18,7 @@ app.get('/api/phonenumbers/parse/text/:phoneNumber', (req, res) => {
   }
   else {
     var arr = [];
-    arr.push(req.params.phoneNumber);
+    arr= req.params.phoneNumber.split(',');
     var finalArr = numParser(arr, res);
 
     res.status(200).send(finalArr);


### PR DESCRIPTION
Libphoneparser is created to parse, format, and validate separate snippets of strings that are each meant to contain a single phone. In order to have GET handle multiple phones, the string needs to have a comma between intended phone numbers to keep the parser from combining them into something that is not valid.